### PR TITLE
Reduce popper shake rotation

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,9 +47,9 @@
 
     @keyframes popperShake {
       0%, 100% { transform: rotate(0deg); }
-      25% { transform: rotate(-15deg); }
-      50% { transform: rotate(15deg); }
-      75% { transform: rotate(-15deg); }
+      25% { transform: rotate(-10deg); }
+      50% { transform: rotate(10deg); }
+      75% { transform: rotate(-10deg); }
     }
 
     .confetti-launcher {


### PR DESCRIPTION
## Summary
- tone down the rotation in popperShake animation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_688857f56abc832fb2cd5b692c377f21