### PR TITLE
Extend confetti duration

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@ document.querySelector('.popper').addEventListener('click', () => {
 
         let frame = 5; // start slightly out for immediate spread
         // keep the confetti visible for longer
-        const maxFrames = 200;
+        const maxFrames = 400; // extend confetti duration
 
         function animate() {
           const dx = x * frame;


### PR DESCRIPTION
## Summary
- keep confetti visible longer so celebrations are harder to miss

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68885af575b8832f9532c712d768a9d0