### PR TITLE
Allow continued confetti after reveal

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,10 +132,14 @@
     }
 
     function updateProgress(amount) {
-      if (progress >= 100) return;
-      progress = Math.min(100, progress + amount);
-      progressBar.style.width = progress + '%';
-      if (progress === 100) {
+      if (progress < 100) {
+        progress = Math.min(100, progress + amount);
+        progressBar.style.width = progress + '%';
+        if (progress === 100) {
+          revealConfetti();
+        }
+      } else {
+        // Once the bar is full, keep celebrating on further shakes/clicks
         revealConfetti();
       }
     }


### PR DESCRIPTION
## Summary
- enable confetti to pop even after the progress bar is full

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688907cb973c832f97b0283a2bddd65a