### PR TITLE
Adjust confetti animation and layering

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
   background-repeat: no-repeat;
   background-position: center;
   transform-origin: center bottom;
+  z-index: 2;
 }
 
     .popper.shake {
@@ -73,6 +74,7 @@
       opacity: 0.9;
       pointer-events: none;
       will-change: transform;
+      z-index: 1;
     }
 
     @keyframes confettiFly {
@@ -188,7 +190,7 @@ document.querySelector('.popper').addEventListener('click', () => {
         confetti.style.width = width + 'px';
         confetti.style.height = height + 'px';
 
-        const angleDeg = -100 + Math.random() * 80;
+        const angleDeg = -90 + (Math.random() * 40 - 20);
         const distance = 80 + Math.random() * 120;
         const rotate = Math.random() * 720 - 360;
 


### PR DESCRIPTION
## Summary
- keep confetti behind the popper
- launch confetti vertically instead of toward the side

## Testing
- `git diff --color`

------
https://chatgpt.com/codex/tasks/task_b_68899ba05320832f86d8a94a070cc623