### PR TITLE
Tune confetti animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,6 +115,7 @@
 
     @keyframes confettiFly {
       0% { transform: translate3d(0,0,0) rotate(0deg); opacity: 1; }
+      85% { opacity: 1; }
       100% { transform: translate3d(var(--dx), var(--dy), 0) rotate(var(--rotate)); opacity: 0; }
     }
 
@@ -125,6 +126,10 @@
       }
       15% {
         transform: translate3d(var(--mid-dx), var(--mid-dy), 0) rotate(calc(var(--rotate) * 0.5));
+        opacity: 1;
+      }
+      85% {
+        opacity: 1;
       }
       100% {
         transform: translate3d(var(--dx), var(--dy), 0) rotate(var(--rotate));


### PR DESCRIPTION
## Summary
- keep confetti visible for longer by delaying its opacity drop

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_688a5e7a8d14832f9f0a2fec8459c237