### PR TITLE
Fix popper fading when balloons drop

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,6 +311,7 @@ document.querySelector('.popper').addEventListener('click', () => {
     function dropBalloons() {
       const container = document.getElementById('container');
       const images = ['pinkballoon1.png', 'pinkballoon2.png', 'pinkballoon3.png'];
+      popper.classList.remove('shake');
       popper.classList.add('fade-out');
       popper.addEventListener('animationend', () => popper.remove(), { once: true });
       for (let i = 0; i < 20; i++) {


### PR DESCRIPTION
## Summary
- ensure fade out animation can run by removing `shake` class before applying `fade-out`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688a6229f998832fac8147780df07392