### PR TITLE
Adjust balloon and message timings

### DIFF
--- a/index.html
+++ b/index.html
@@ -362,7 +362,7 @@ document.querySelector('.popper').addEventListener('click', () => {
         balloon.style.setProperty('--sway', (10 + Math.random() * 20) + 'px');
 
         const delay = Math.random() * 2;
-        const dropDuration = 2.5 + Math.random() * 2; // faster & varied
+        const dropDuration = (2.5 + Math.random() * 2) * 0.75; // 25% faster
         const swayDuration = 2 + Math.random() * 2;
         balloon.style.animation =
           `balloonDrop ${dropDuration}s linear ${delay}s forwards, ` +
@@ -373,7 +373,7 @@ document.querySelector('.popper').addEventListener('click', () => {
       }
 
       if (overlayMessage) {
-        setTimeout(showOverlayMessage, 1000);
+        setTimeout(showOverlayMessage, 1250); // 25% longer delay
       }
     }
   </script>


### PR DESCRIPTION
## Summary
- shorten the balloon drop animation by 25%
- delay overlay message display by 25%

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688a698ea910832f89cf7b82ce48b19b