### PR TITLE
Add shake prompt text

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,6 +234,30 @@
     z-index: 2000;
   }
 
+#pre-family-text, #post-family-text {
+    position: absolute;
+    left: 7%;
+    width: 86%;
+    height: 12.7%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    font-family: 'League Spartan', sans-serif;
+    color: #333333;
+    text-transform: uppercase;
+    pointer-events: none;
+    z-index: 2000;
+  }
+
+#pre-family-text {
+    top: 0%;
+  }
+
+#post-family-text {
+    top: 24%;
+  }
+
   </style>
 </head>
 <body>
@@ -242,7 +266,9 @@
     <div class="confetti-launcher"></div>
     <div id="shake-header"></div>
     <div id="click-prompt"></div>
+    <div id="pre-family-text">SHAKE TO SEE WHAT</div>
     <div id="family-name"></div>
+    <div id="post-family-text">WILL BE</div>
     <button id="enable-motion">Enable Motion</button>
     <div id="message-overlay"></div>
   </div>
@@ -258,6 +284,8 @@
     const messageOverlay = document.getElementById('message-overlay');
     const urlParams = new URLSearchParams(window.location.search);
     const familyNameDiv = document.getElementById("family-name");
+    const preFamilyText = document.getElementById("pre-family-text");
+    const postFamilyText = document.getElementById("post-family-text");
     const familyName = urlParams.get("family");
     if (familyName) {
       const letters = familyName.replace(/\s+/g, "").length || 1;
@@ -268,6 +296,12 @@
     } else {
       familyNameDiv.style.display = "none";
     }
+    const preLetters = preFamilyText.textContent.replace(/\s+/g, "").length || 1;
+    preFamilyText.style.fontSize = Math.min(12, 50 / preLetters) + "vmin";
+    preFamilyText.style.display = "flex";
+    const postLetters = postFamilyText.textContent.replace(/\s+/g, "").length || 1;
+    postFamilyText.style.fontSize = Math.min(12, 50 / postLetters) + "vmin";
+    postFamilyText.style.display = "flex";
     const genderParam = (urlParams.get('gender') || '').toLowerCase();
     let overlayMessage = urlParams.get('message');
     if (!overlayMessage && genderParam) {


### PR DESCRIPTION
## Summary
- add two lines of overlay text above and below the family name block
- size the new text dynamically like the family name

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688adae18338832fb6dadc0b00673c39